### PR TITLE
Don't force unique codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ This bundle provides several default ElementData types:
 
 You can extend or overwrite these, as long as your ElementData implements the correct interface, matching the `type` of the Element.
 
+### Display conditions
+
+This bundle provides a service to check if a given ElementUsage should be displayed, based on a given SurveyResponse.  
+To identify elements, it uses the `code` parameter of the ElementUsage.  
+The provided `displayConditionService` assumes that `ElementUsage->display_condition` contains a valid expression, see [Symfony Expression Language](https://symfony.com/doc/current/components/expression_language.html).  
+So make sure, this code is unique in the set you are checking, usually this means, that it should be unique in the related survey.
+
 ## Services
 
 This bundle contains several services to use in your survey-project. These are injected automatically when using their interfaces.

--- a/src/Entity/Traits/ElementUsageTrait.php
+++ b/src/Entity/Traits/ElementUsageTrait.php
@@ -27,7 +27,8 @@ trait ElementUsageTrait
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     protected ?string $displayCondition = null;
 
-    #[ORM\Column(length: 255, unique: true)]
+    // Please note; in order to let conditions work properly, this code should be unique, at least per survey.
+    #[ORM\Column(length: 255)]
     protected string $code = '';
 
     #[ORM\ManyToOne(inversedBy: 'elementUsages')]
@@ -81,6 +82,11 @@ trait ElementUsageTrait
         return $this->code;
     }
 
+    /**
+     * Please note; in order to let conditions work properly, this code should be unique, at least per survey.
+     * @param string $code
+     * @return $this
+     */
     public function setCode(string $code): static
     {
         $this->code = $code;


### PR DESCRIPTION
Don't force unique codes.
this is important for conditions, but can differ per project; usually they should be unique per survey, not in general in the whole system.