### PR TITLE
Improve handling of the Multiple Choice Grid

### DIFF
--- a/src/Entity/ElementData/MultipleChoiceGridQuestionElementData.php
+++ b/src/Entity/ElementData/MultipleChoiceGridQuestionElementData.php
@@ -81,7 +81,11 @@ class MultipleChoiceGridQuestionElementData extends ElementData implements Multi
             }
         }
 
-        $this->questions = $questions;
+        $this->questions = [];
+        foreach ($questions as $question) {
+            $this->addQuestion($question);
+        }
+
         return $this;
     }
 
@@ -90,6 +94,12 @@ class MultipleChoiceGridQuestionElementData extends ElementData implements Multi
         if (array_key_exists($question->getUniqueIdentifier(), $this->questions)) {
             throw new InvalidArgumentException('Question with this unique identifier already exists');
         }
+        $this->questions[$question->getUniqueIdentifier()] = $question;
+        return $this;
+    }
+
+    public function overrideQuestion(MultipleChoiceGridQuestionQuestionInterface $question): static
+    {
         $this->questions[$question->getUniqueIdentifier()] = $question;
         return $this;
     }

--- a/src/Service/ValidateAnswerService.php
+++ b/src/Service/ValidateAnswerService.php
@@ -246,7 +246,7 @@ class ValidateAnswerService implements ValidateAnswerServiceInterface
                     );
                     if (count($foundQuestions) !== 1) {
                         $context
-                            ->buildViolation('This provided answer has an answer with an unrecognized uniqueQuestionIdentifier')
+                            ->buildViolation('This provided answer has an answer with an unrecognized uniqueQuestionIdentifier "%identifier%"', ['%identifier%' => $rawAnswerItem['uniqueQuestionIdentifier']])
                             ->addViolation()
                         ;
                     }
@@ -261,11 +261,17 @@ class ValidateAnswerService implements ValidateAnswerServiceInterface
                         }
                         if (!$rawAnswerOptionFound) {
                             $context
-                                ->buildViolation('The value you selected is not a valid choice.')
+                                ->buildViolation('The value: %value% is not a valid choice.', ['%value%' => json_encode($rawAnswerItemAnswer)])
                                 ->addViolation()
                             ;
                         }
                     }
+                }
+                if (count($rawAnswer) != count($elementData->getQuestions())) {
+                    $context
+                        ->buildViolation('You need to answer all of the questions.')
+                        ->addViolation()
+                    ;
                 }
             }),
         ];


### PR DESCRIPTION
Make sure addQuestion and setQuestions follow the same logic.
Allow replacing the existing questions.
Add descriptive error messages.
Make sure number of answers is equal to number of questions in multiple choice grid.